### PR TITLE
Fix SQ-SAST GitHub Action metadata to send full repository URL

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -83,7 +83,7 @@ runs:
 
         echo "./accuknox-aspm-scanner scan $SOFT_FAIL_ARG sq-sast $SKIP_FLAG \
                 --command \"$CMD_ARGS\" \
-                --repo-url \"$GITHUB_REPOSITORY\" \
+                --repo-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY\" \
                 --branch \"${GITHUB_REF#refs/heads/}\" \
                 --commit-sha \"$GITHUB_SHA\" \
                 --pipeline-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\" \
@@ -91,7 +91,7 @@ runs:
         
         ./accuknox-aspm-scanner scan $SOFT_FAIL_ARG sq-sast $SKIP_FLAG \
           --command "$CMD_ARGS" \
-          --repo-url "$GITHUB_REPOSITORY" \
+          --repo-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
           --branch "${GITHUB_REF#refs/heads/}" \
           --commit-sha "$GITHUB_SHA" \
           --pipeline-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \

--- a/action.yaml
+++ b/action.yaml
@@ -63,7 +63,7 @@ runs:
         fi
 
         echo "Downloading AccuKnox ASPM Scanner..."
-        curl -L https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.0/accuknox-aspm-scanner -o accuknox-aspm-scanner
+        curl -L https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.14.2/accuknox-aspm-scanner -o accuknox-aspm-scanner
         chmod +x accuknox-aspm-scanner
 
         # Build SonarQube properties (no skip flag here)
@@ -83,7 +83,6 @@ runs:
 
         echo "./accuknox-aspm-scanner scan $SOFT_FAIL_ARG sq-sast $SKIP_FLAG \
                 --command \"$CMD_ARGS\" \
-                --repo-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY\" \
                 --branch \"${GITHUB_REF#refs/heads/}\" \
                 --commit-sha \"$GITHUB_SHA\" \
                 --pipeline-url \"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\" \
@@ -91,7 +90,6 @@ runs:
         
         ./accuknox-aspm-scanner scan $SOFT_FAIL_ARG sq-sast $SKIP_FLAG \
           --command "$CMD_ARGS" \
-          --repo-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
           --branch "${GITHUB_REF#refs/heads/}" \
           --commit-sha "$GITHUB_SHA" \
           --pipeline-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \


### PR DESCRIPTION
This PR updates the sast-scan-action invocation to pass a fully qualified repository URL instead of the GitHub repository slug.

**Why this change was required**

- The action was passing --repo-url "$GITHUB_REPOSITORY" (e.g., owner/repo), which is not a URL and has no hostname.
- Downstream SonarQube parsing expects hostname-capable platform/repository metadata.